### PR TITLE
Add .gitignore to exclude common files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Dependencies
+node_modules/
+*.log
+
+# Environment variables
+.env
+.env.local
+
+# Build outputs
+dist/
+build/
+*.min.js
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+venv/
+
+# Temporary files
+*.tmp
+*.cache


### PR DESCRIPTION
Added .gitignore file to prevent tracking of common build artifacts, dependencies, environment files, and IDE-specific configurations. This keeps the repository clean and focused on source code.